### PR TITLE
Page title and favicon work also in production

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -4,6 +4,7 @@ WORKDIR /app
 COPY package*.json *.config.js ./
 RUN npm install
 COPY ./src ./src
+COPY ./public ./public
 
 ARG SERVER_WS
 ENV SERVER_WS "$SERVER_WS"


### PR DESCRIPTION
The problem was that the `public` folder wasn't copied in the Dockerfile and thus not taken into consideration when building the app.

Fixes #20 and perhaps also fixes the icon problem so the previous fix can be undone again.