### PR TITLE
Enable Local development

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,12 +9,12 @@ services:
     volumes:
       - db:/var/lib/postgresql/data
     networks:
-      - internal
+      - backend-internal
 
   redis:
     image: "redis:alpine"
     networks:
-      - internal
+      - backend-internal
 
   storage:
     image: quay.io/minio/minio:RELEASE.2021-09-09T21-37-07Z
@@ -27,7 +27,7 @@ services:
     volumes:
       - storage:/data
     networks:
-      - internal
+      - backend-internal
 
   backend:
     build:
@@ -41,7 +41,8 @@ services:
       - env_files/minio.env
       - env_files/backend.env
     networks:
-      - internal
+      - backend-internal
+      - backend
     depends_on:
       - db
       - storage
@@ -56,7 +57,7 @@ services:
       - env_files/minio.env
       - env_files/exam_marker.env
     networks:
-      - internal
+      - backend-internal
     depends_on:
       - db
       - storage
@@ -66,16 +67,19 @@ services:
     build:
       context: frontend
       args:
-        SERVER_HTTP: http://localhost:8081/query
+        SERVER_HTTP: http://localhost:8080/query
         SERVER_WS: ws://localhost:8081/query
     image: "altklausur_ausleihe-frontend:latest"
     ports:
       - "127.0.0.1:8080:80"
+    networks:
+      - backend
     depends_on:
       - backend
 
 networks:
-  internal: {}
+  backend-internal: {}
+  backend: {}
 
 volumes:
   db: {}

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -1,14 +1,33 @@
+upstream backend-upstream {
+    server backend:8081;
+}
+
 server {
     listen       80;
     listen  [::]:80;
-    server_name  localhost;
 
-    #access_log  /var/log/nginx/host.access.log  main;
+    server_name  localhost;
 
     location / {
         root   /usr/share/nginx/html;
         index  index.html index.htm;
         try_files $uri $uri/ /index.html;
+    }
+
+    location /query {
+        proxy_pass http://backend-upstream/query;
+    }
+
+    location /testlogin {
+        proxy_pass http://backend-upstream/testlogin;
+    }
+
+    location /distributor/lti_launch {
+        proxy_pass http://backend-upstream/distributor/lti_launch;
+    }
+
+    location /distributor/lti_config {
+        proxy_pass http://backend-upstream/distributor/lti_config;
     }
 
     error_page   500 502 503 504  /50x.html;

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -8,7 +8,7 @@ RUN go mod download
 
 COPY server/graph ./server/graph
 COPY server/lti_utils ./server/lti_utils
-COPY server/server.go ./server/
+COPY server/server.go server/dummylogin.html ./server/
 COPY utils ./utils
 
 RUN go build -a -o graphQLServer.runnable server/server.go

--- a/server/dummylogin.html
+++ b/server/dummylogin.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width" />
+        <title>Dummysite</title>
+    </head>
+    <body>
+        <h1>Testlogin</h1>
+        <form action="/distributor/lti_launch" method="post" id="form1">
+        <button type="submit" form="form1" value="Submit">Create JWT Token for session</button> 
+    </body>
+</html>

--- a/server/lti_utils/lti.go
+++ b/server/lti_utils/lti.go
@@ -165,5 +165,5 @@ func (l *LTIConnector) DummyLTILaunch(w http.ResponseWriter, r *http.Request) {
 	jwtCookie := &http.Cookie{Name: "jwt", Value: tokenString, HttpOnly: false, Path: "/"}
 	http.SetCookie(w, jwtCookie)
 
-	http.Redirect(w, r, "https://"+r.Host+"/", http.StatusMovedPermanently)
+	http.Redirect(w, r, "/", http.StatusMovedPermanently)
 }

--- a/server/server.go
+++ b/server/server.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"text/template"
 
 	"github.com/99designs/gqlgen/graphql/handler"
 	"github.com/99designs/gqlgen/graphql/handler/extension"
@@ -67,6 +68,11 @@ func main() {
 	if os.Getenv("DEPLOYMENT_ENV") == "testing" {
 		router.Handle("/", playground.Handler("GraphQL playground", "/query"))
 		log.Printf("connect to http://localhost:%s/ for GraphQL playground", port)
+
+		router.Get("/testlogin", func(w http.ResponseWriter, r *http.Request) {
+			tmpl := template.Must(template.ParseFiles("server/dummylogin.html"))
+			tmpl.Execute(w, nil)
+		})
 	}
 
 	router.Get("/distributor/lti_config", lti_utils.LTIConfigHandler)

--- a/server/test_upload.sh
+++ b/server/test_upload.sh
@@ -20,7 +20,7 @@ if [ "$1" == "" ] || [ $# -ne 1 ]; then
 fi
 
 JWT_TOKEN="ADD.YOUR.TOKEN"
-TARGET_HOST='http://localhost:8081/query' 
+TARGET_HOST='http://localhost:8080/query'
 # TARGET_HOST='https://altklausuren.mathphys.info/query'
 
 set -o nounset                              # Treat unset variables as an error
@@ -29,8 +29,7 @@ curl --silent $TARGET_HOST \
     -H 'Cookie: jwt='$JWT_TOKEN \
     -F operations='{ "query": "mutation createNewExam($input: NewExam!) {createExam(input: $input) {UUID, subject, moduleName, examiners} }", "variables": { "input": { "subject": "Info", "moduleName": "Betriebssysteme und Netzwerke", "moduleAltName": "IBN, BeNe", "year": 2021, "semester": "SoSe", "examiners": "Tom Rix", "file": null } } }' \
     -F map='{ "0": ["variables.input.file"] }' \
-    -F 0=@$1 | \
-    jq
+    -F 0=@$1
 
 # Original:
 # curl localhost:8081/query \


### PR DESCRIPTION
This enables sensible local development by adding a dummylogin (`http://localhost:8080/testlogin`) which gives you a JWT token for the browser session!
To achive this, the frontend's NGinX now communicates to the backend and (in theory) no direct access to the backend should be necessary.
