### PR TITLE
Fixed paddings between questions

### DIFF
--- a/frontend/src/components/ExamList.vue
+++ b/frontend/src/components/ExamList.vue
@@ -194,12 +194,15 @@
               <v-icon class="pr-3" large>mdi-help</v-icon>
               {{ $t("help.help") }}
             </v-toolbar>
-            <v-card-text class="pa-6" v-for='(item, i) in $t("help.questions_and_answers")' v-bind:key="i">
-              <div class="text-h6 pa-2">
-                {{ i+1 }}. {{ item.question }}
-              </div>
-              <div class="text pa-2">
-                {{ item.answer }}
+            <v-card-text class="pa-6">
+              <div
+                v-for="(item, i) in $t('help.questions_and_answers')"
+                v-bind:key="i"
+              >
+                <div class="text-h6 pa-2">{{ i + 1 }}. {{ item.question }}</div>
+                <div class="text pa-2">
+                  {{ item.answer }}
+                </div>
               </div>
             </v-card-text>
             <v-card-actions class="justify-end">


### PR DESCRIPTION
When iterating over v-card the padding is set around every question. I've changed it so that it is only set around all questions in total, so that less space is in between questions.