### PR TITLE
Prometheus Metrics

### DIFF
--- a/server/graph/schema.resolvers.go
+++ b/server/graph/schema.resolvers.go
@@ -26,7 +26,7 @@ import (
 	"github.com/dustin/go-humanize"
 	"github.com/gabriel-vasile/mimetype"
 	minio "github.com/minio/minio-go/v7"
-	"github.com/satori/go.uuid"
+	uuid "github.com/satori/go.uuid"
 	"gorm.io/gorm"
 )
 
@@ -138,6 +138,9 @@ func (r *mutationResolver) CreateExam(ctx context.Context, input model.NewExam) 
 		return nil, uploadErr
 	}
 
+	// update the TotalExams metric
+	utils.GetTotalExamsMetric(r.DB)
+
 	return &exam, nil
 }
 
@@ -201,6 +204,8 @@ func (r *mutationResolver) RequestMarkedExam(ctx context.Context, stringUUID str
 	if err := tagQueue.Publish(string(task)); err != nil {
 		return nil, err
 	}
+
+	utils.ExamsMarkedMetric.Inc()
 
 	return &stringUUID, nil
 }

--- a/server/server.go
+++ b/server/server.go
@@ -35,9 +35,10 @@ func main() {
 	}
 
 	router := chi.NewRouter()
-	m := chiprometheus.NewMiddleware("altklausur_web_service")
 
-	router.Use(m)
+	prometheusMiddleware := chiprometheus.NewMiddleware("altklausur_web_service")
+	router.Use(prometheusMiddleware)
+
 	// Add CORS middleware around every request
 	// See https://github.com/rs/cors for full option listing
 	router.Use(cors.New(cors.Options{
@@ -104,7 +105,12 @@ func main() {
 		r.Handle("/query", srv)
 		r.Get("/adminlogin", authHelper.AdminLoginHandler)
 	})
+
+	// set the TotalExams metric initially
+	utils.GetTotalExamsMetric(db)
+
 	router.Handle("/metrics", promhttp.Handler())
+
 	fmt.Print(
 		"==========================================\n",
 		"Started the backend listening on Port "+port+"\n",

--- a/utils/prometheus.go
+++ b/utils/prometheus.go
@@ -1,0 +1,28 @@
+package utils
+
+import (
+	"github.com/FachschaftMathPhysInfo/altklausur-ausleihe/server/graph/model"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	"gorm.io/gorm"
+)
+
+var (
+	// ExamsMarkedMetric is a prometheus metric for the amount of requested exams for watermarking
+	ExamsMarkedMetric = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "altklausur_ausleihe_exams_requested",
+		Help: "The total number of requested exams",
+	})
+
+	// TotalExamsMetric is a prometheus metric for the total amount of exams in the database
+	TotalExamsMetric = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "altklausur_ausleihe_exams_total",
+		Help: "The total number of exams",
+	})
+)
+
+func GetTotalExamsMetric(database *gorm.DB) {
+	var count int64
+	database.Model(&model.Exam{}).Count(&count)
+	TotalExamsMetric.Set(float64(count))
+}


### PR DESCRIPTION
Creates the following two metrics for prometheus:
- `ExamsMarkedMetric` (is `altklausur_ausleihe_exams_requested`)
- `TotalExamsMetric` (is `altklausur_ausleihe_exams_total`)

related to https://github.com/FachschaftMathPhysInfo/altklausur-ausleihe/issues/49
