### PR TITLE
Prometheus Metrics: Duration for the watermarking/queueing

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,6 +58,7 @@ services:
       - env_files/exam_marker.env
     networks:
       - backend-internal
+      - backend
     depends_on:
       - db
       - storage

--- a/exam_marker/Dockerfile
+++ b/exam_marker/Dockerfile
@@ -38,6 +38,7 @@ COPY server/graph ./server/graph
 COPY server/lti_utils ./server/lti_utils
 
 COPY exam_marker/exam_marker.go ./exam_marker/exam_marker.go
+COPY exam_marker/prometheus ./exam_marker/prometheus
 COPY utils ./utils
 RUN go build -a -o exam_marker.runnable ./exam_marker/exam_marker.go
 

--- a/exam_marker/exam_marker.go
+++ b/exam_marker/exam_marker.go
@@ -43,7 +43,6 @@ var (
 
 type RMQConsumer struct {
 	name        string
-	count       int
 	before      time.Time
 	MinIOClient *minio.Client
 }
@@ -51,7 +50,6 @@ type RMQConsumer struct {
 func NewRMQConsumer(minioClient *minio.Client, tag int) *RMQConsumer {
 	return &RMQConsumer{
 		name:        fmt.Sprintf("consumer%d", tag),
-		count:       0,
 		before:      time.Now(),
 		MinIOClient: minioClient,
 	}
@@ -66,6 +64,8 @@ func (consumer *RMQConsumer) Consume(delivery rmq.Delivery) {
 	}
 	log.Printf("%s working on task %q", consumer.name, task.ExamUUID)
 	executeMarkerTask(consumer.MinIOClient, task)
+
+	log.Printf("%s took %v to work on task %q", consumer.name, time.Since(task.SubmitTime), task.ExamUUID)
 
 	if err := delivery.Ack(); err != nil {
 		log.Println(err)

--- a/exam_marker/prometheus/prometheus.go
+++ b/exam_marker/prometheus/prometheus.go
@@ -1,0 +1,14 @@
+package prometheus
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+var (
+	// WatermarkingTimeHistogram is a prometheus metric for the total amount of exams in the database
+	WatermarkingTimeHistogram = promauto.NewHistogram(prometheus.HistogramOpts{
+		Name: "altklausur_ausleihe_watermarking_histogram",
+		Help: "histogram for the time it takes an exam to get marked",
+	})
+)

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -2,6 +2,10 @@ upstream backend-upstream {
     server backend:8081;
 }
 
+upstream exam_marker-upstream {
+    server exam_marker:8081;
+}
+
 server {
     listen       80;
     listen  [::]:80;
@@ -35,8 +39,12 @@ server {
         proxy_pass http://backend-upstream/adminlogin;
     }
 
-    location /metrics {
+    location /backend/metrics {
         proxy_pass http://backend-upstream/metrics;
+    }
+
+    location /exam_marker/metrics {
+        proxy_pass http://exam_marker-upstream/metrics;
     }
     
     error_page   500 502 503 504  /50x.html;

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -8,6 +8,7 @@ RUN go mod download
 
 COPY server/graph ./server/graph
 COPY server/lti_utils ./server/lti_utils
+COPY server/prometheus ./server/prometheus
 COPY server/server.go server/dummylogin.html ./server/
 COPY utils ./utils
 

--- a/server/graph/schema.resolvers.go
+++ b/server/graph/schema.resolvers.go
@@ -22,6 +22,7 @@ import (
 	"github.com/FachschaftMathPhysInfo/altklausur-ausleihe/server/graph/generated"
 	"github.com/FachschaftMathPhysInfo/altklausur-ausleihe/server/graph/model"
 	"github.com/FachschaftMathPhysInfo/altklausur-ausleihe/server/lti_utils"
+	"github.com/FachschaftMathPhysInfo/altklausur-ausleihe/server/prometheus"
 	"github.com/FachschaftMathPhysInfo/altklausur-ausleihe/utils"
 	"github.com/dustin/go-humanize"
 	"github.com/gabriel-vasile/mimetype"
@@ -139,7 +140,7 @@ func (r *mutationResolver) CreateExam(ctx context.Context, input model.NewExam) 
 	}
 
 	// update the TotalExams metric
-	utils.UpdateTotalExamsMetric(r.DB)
+	prometheus.UpdateTotalExamsMetric(r.DB)
 
 	return &exam, nil
 }
@@ -206,7 +207,7 @@ func (r *mutationResolver) RequestMarkedExam(ctx context.Context, stringUUID str
 		return nil, err
 	}
 
-	utils.ExamsMarkedMetric.Inc()
+	prometheus.ExamsMarkedMetric.Inc()
 
 	return &stringUUID, nil
 }

--- a/server/graph/schema.resolvers.go
+++ b/server/graph/schema.resolvers.go
@@ -193,6 +193,7 @@ func (r *mutationResolver) RequestMarkedExam(ctx context.Context, stringUUID str
 			UserID:       userInfos.ID,
 			TextLeft:     userInfos.PersonFamilyName + " - " + userInfos.PersonFamilyName,
 			TextDiagonal: userInfos.PersonPrimaryEmail,
+			SubmitTime:   time.Now(),
 		},
 	)
 

--- a/server/prometheus/prometheus.go
+++ b/server/prometheus/prometheus.go
@@ -1,4 +1,4 @@
-package utils
+package prometheus
 
 import (
 	"github.com/FachschaftMathPhysInfo/altklausur-ausleihe/server/graph/model"

--- a/server/server.go
+++ b/server/server.go
@@ -15,6 +15,7 @@ import (
 	"github.com/FachschaftMathPhysInfo/altklausur-ausleihe/server/graph"
 	"github.com/FachschaftMathPhysInfo/altklausur-ausleihe/server/graph/generated"
 	"github.com/FachschaftMathPhysInfo/altklausur-ausleihe/server/lti_utils"
+	"github.com/FachschaftMathPhysInfo/altklausur-ausleihe/server/prometheus"
 	"github.com/FachschaftMathPhysInfo/altklausur-ausleihe/utils"
 	chiprometheus "github.com/edjumacator/chi-prometheus"
 	"github.com/go-chi/chi/v5"
@@ -107,7 +108,7 @@ func main() {
 	})
 
 	// set the TotalExams metric initially
-	utils.UpdateTotalExamsMetric(db)
+	prometheus.UpdateTotalExamsMetric(db)
 
 	router.Handle("/metrics", promhttp.Handler())
 

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -220,9 +220,11 @@ func GetExamCachePath(userID string, examUUID uuid.UUID) string {
 	return userID + "_" + examUUID.String()
 }
 
+// RMQMarkerTask models one of the tasks on the exam queue
 type RMQMarkerTask struct {
 	ExamUUID     uuid.UUID `json:"examuuid"`
 	UserID       string    `json:"userid"`
 	TextLeft     string    `json:"textleft"`
 	TextDiagonal string    `json:"textdiagonal"`
+	SubmitTime   time.Time `json:"submittime"`
 }


### PR DESCRIPTION
This adds the possibility to record the time it takes a exam to be marked as a prometheus [histogram](https://prometheus.io/docs/concepts/metric_types/#histogram).

- add time tracking to a task
- move the prometheus metrics into their own package as child of server
- add time metrics to the backend

related to https://github.com/FachschaftMathPhysInfo/altklausur-ausleihe/issues/49
